### PR TITLE
Use KERNEL_VERSION macro to handle different kernel version

### DIFF
--- a/mmc-mailbox-driver.c
+++ b/mmc-mailbox-driver.c
@@ -3,6 +3,7 @@
  * "Virtual EEPROM" driver for DMMC-STAMP Mailbox
  *
  * Copyright (C) 2022 Patrick Huesmann, DESY
+ * Copyright (C) 2025 Atom Computing, Inc.
  *
  * Based on at24.c by David Brownell & Wolfram Sang
  *
@@ -20,6 +21,7 @@
 #include <linux/property.h>
 #include <linux/regmap.h>
 #include <linux/slab.h>
+#include <linux/version.h>
 
 #include <linux/mod_devicetable.h>
 #include <linux/nvmem-provider.h>
@@ -482,7 +484,13 @@ static int mmc_mailbox_probe(struct i2c_client* client)
     return 0;
 }
 
-static void mmc_mailbox_remove(struct i2c_client* client)
+static
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
+int
+#else
+void
+#endif
+mmc_mailbox_remove(struct i2c_client* client)
 {
     pm_runtime_disable(&client->dev);
     pm_runtime_set_suspended(&client->dev);
@@ -490,6 +498,10 @@ static void mmc_mailbox_remove(struct i2c_client* client)
     if (pm_power_off == &mmc_mailbox_do_poweroff) {
         pm_power_off = NULL;
     }
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
+    return 0;
+#endif
 }
 
 static struct i2c_driver mmc_mailbox_driver = {
@@ -498,7 +510,11 @@ static struct i2c_driver mmc_mailbox_driver = {
             .name = "mmc_mailbox",
             .of_match_table = mmc_mailbox_of_match,
         },
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
+    .probe_new = mmc_mailbox_probe,
+#else
     .probe = mmc_mailbox_probe,
+#endif
     .remove = mmc_mailbox_remove,
     .id_table = mmc_mailbox_ids,
 };

--- a/mmc-mailbox-driver.c
+++ b/mmc-mailbox-driver.c
@@ -498,7 +498,7 @@ static struct i2c_driver mmc_mailbox_driver = {
             .name = "mmc_mailbox",
             .of_match_table = mmc_mailbox_of_match,
         },
-    .probe_new = mmc_mailbox_probe,
+    .probe = mmc_mailbox_probe,
     .remove = mmc_mailbox_remove,
     .id_table = mmc_mailbox_ids,
 };

--- a/mmc-mailbox-driver.c
+++ b/mmc-mailbox-driver.c
@@ -482,7 +482,7 @@ static int mmc_mailbox_probe(struct i2c_client* client)
     return 0;
 }
 
-static int mmc_mailbox_remove(struct i2c_client* client)
+static void mmc_mailbox_remove(struct i2c_client* client)
 {
     pm_runtime_disable(&client->dev);
     pm_runtime_set_suspended(&client->dev);
@@ -490,8 +490,6 @@ static int mmc_mailbox_remove(struct i2c_client* client)
     if (pm_power_off == &mmc_mailbox_do_poweroff) {
         pm_power_off = NULL;
     }
-
-    return 0;
 }
 
 static struct i2c_driver mmc_mailbox_driver = {


### PR DESCRIPTION
This MR adds KERNEL_VERSION macro to handle the subtle differences between different kernel version.

It was tested with kernel versions `5.4.0` and `6.6.40`, don't have a setup ready for `6.1` and have skipped that.